### PR TITLE
handoff: fix RAG S3 sync to /app/rag_store/prompts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ networks:
 
 volumes:
   rag-cache:
+  rag-store:
 
 services:
   security-svc:
@@ -69,6 +70,7 @@ services:
   rag-svc:
     build: { context: ., dockerfile: services/rag/Dockerfile }
     container_name: rag-svc
+    env_file: .env
     restart: unless-stopped
     networks:
       app-net:
@@ -87,12 +89,18 @@ services:
     pids_limit: 512
     logging: { driver: "local", options: { max-size: "10m", max-file: "5" } }
     environment:
+      RAG_MODE: structured
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}
       S3_BUCKET: ${S3_BUCKET}
       S3_PREFIX: ${S3_PREFIX}
+      RAG_STORE_DIR: /app/rag_store
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-https://storage.yandexcloud.net}
       S3_REGION: ${S3_REGION:-ru-central1}
+      AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${S3_SECRET_KEY}
+      AWS_DEFAULT_REGION: ${S3_REGION:-ru-central1}
+      AWS_ENDPOINT_URL: ${S3_ENDPOINT_URL:-https://storage.yandexcloud.net}
       EMB_MODEL: ${EMB_MODEL:-sentence-transformers/distiluse-base-multilingual-cased-v2}
       CHUNK_SIZE: ${CHUNK_SIZE:-600}
       CHUNK_OVERLAP: ${CHUNK_OVERLAP:-200}
@@ -101,10 +109,13 @@ services:
       APP_USER: appuser
       APP_UID: "1000"
       APP_GID: "1000"
+      PERS_PATH: /app/rag_store/prompts/pers.json
+      SYSTEM_PROMPT_PATH: /app/rag_store/prompts/system_client.md
 
     volumes:
       - ./services/rag/vectorstore_faiss:/data/vectorstore_faiss
       - rag-cache:/app/.cache
+      - rag-store:/app/rag_store 
     depends_on:
       security-svc:
         condition: service_healthy

--- a/services/rag/Dockerfile
+++ b/services/rag/Dockerfile
@@ -17,7 +17,8 @@ RUN mkdir -p /app/.cache
 COPY services/rag/requirements.txt /app/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-input --upgrade pip setuptools wheel && \
-    pip install --no-input -r requirements.txt
+    pip install --no-input -r requirements.txt \
+    && pip install --no-input awscli
 
 ARG APP_UID=1000
 ARG APP_GID=1000
@@ -26,6 +27,9 @@ RUN groupadd -g ${APP_GID} appuser && useradd -m -u ${APP_UID} -g ${APP_GID} app
 COPY services/rag/app.py /app/app.py
 COPY services/rag/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+ENV PERS_PATH="/app/rag_store/characters/demo/pers.json" \
+    SYSTEM_PROMPT_PATH="/app/rag_store/prompts/system_client.md"
 
 ENV VSTORE_DIR=/data/vectorstore_faiss \
     S3_ACCESS_KEY="" \
@@ -43,7 +47,9 @@ ENV VSTORE_DIR=/data/vectorstore_faiss \
     APP_UID="1000" \
     APP_GID="1000"
 
-VOLUME ["/data/vectorstore_faiss", "/app/.cache"]
+RUN mkdir -p /app/rag_store && chown -R ${APP_UID}:${APP_GID} /app/rag_store
+
+VOLUME ["/data/vectorstore_faiss", "/app/.cache", "/app/rag_store"]
 EXPOSE 8080
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/services/rag/entrypoint.sh
+++ b/services/rag/entrypoint.sh
@@ -4,14 +4,52 @@ set -euo pipefail
 APP_USER="${APP_USER:-appuser}"
 APP_UID="${APP_UID:-1000}"
 APP_GID="${APP_GID:-1000}"
+RAG_STORE_DIR="${RAG_STORE_DIR:-/app/rag_store}"
+
+export AWS_EC2_METADATA_DISABLED="${AWS_EC2_METADATA_DISABLED:-true}"
 
 echo "[rag] preparing volumes..."
 
-mkdir -p /app/.cache /data/vectorstore_faiss
+mkdir -p /app/.cache /data/vectorstore_faiss "${RAG_STORE_DIR}"
 
-chown -R "$APP_UID:$APP_GID" /app/.cache /data/vectorstore_faiss 2>/dev/null || true
++chown -R "$APP_UID:$APP_GID" /app/.cache /data/vectorstore_faiss "${RAG_STORE_DIR}" 2>/dev/null || true
 find /app/.cache -type d -exec chmod u+rwx,g+rwx {} + 2>/dev/null || true
 find /data/vectorstore_faiss -type d -exec chmod u+rwx,g+rwx {} + 2>/dev/null || true
+find "${RAG_STORE_DIR}" -type d -exec chmod u+rwx,g+rwx {} + 2>/dev/null || true
+
+if [ -n "${S3_BUCKET:-}" ]; then
+  # аккуратно соберём префикс и завершающий слеш
+  _prefix="${S3_PREFIX:-}"
+  if [ -n "$_prefix" ]; then
+    SRC_URI="s3://${S3_BUCKET}/${_prefix%/}/"
+  else
+    SRC_URI="s3://${S3_BUCKET}/"
+  fi
+  echo "[rag] syncing from ${SRC_URI} -> ${RAG_STORE_DIR}/"
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "[rag] FATAL: aws cli not found in image"; exit 1
+  fi
+  # если задан кастомный endpoint (MinIO/YC), используем его
+  if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+    aws s3 sync "${SRC_URI}" "${RAG_STORE_DIR}/" --endpoint-url "${AWS_ENDPOINT_URL}"
+  else
+    aws s3 sync "${SRC_URI}" "${RAG_STORE_DIR}/"
+  fi
+  chown -R "$APP_UID:$APP_GID" "${RAG_STORE_DIR}" 2>/dev/null || true
+  echo "[rag] synced tree:"
+  ls -R "${RAG_STORE_DIR}" || true
+fi
+
+if [ "${RAG_MODE:-structured}" = "structured" ]; then
+  if [ ! -f "${PERS_PATH:-}" ] || [ ! -f "${SYSTEM_PROMPT_PATH:-}" ]; then
+    echo "[rag] ERROR: required files not found:"
+    echo "  PERS_PATH=$PERS_PATH"
+    echo "  SYSTEM_PROMPT_PATH=$SYSTEM_PROMPT_PATH"
+    echo "[rag] ls -R ${RAG_STORE_DIR}:"
+    ls -R "${RAG_STORE_DIR}" || true
+    exit 1
+  fi
+fi
 
 echo "[rag] starting..."
 if command -v gosu >/dev/null 2>&1; then


### PR DESCRIPTION
## Контекст
- Цель: RAG-сервис должен подтягивать из S3 два файла:
  - /app/rag_store/prompts/pers.json
  - /app/rag_store/prompts/system_client.md

## Что сейчас
- Стек поднимается, но rag-svc становится unhealthy
- Ошибка в логах:
rag-svc         | [rag] preparing volumes...
rag-svc         | [rag] syncing from s3://scambot/my-bucket/rag_store_demo/ -> /app/rag_store/
moderation-svc  | INFO:     127.0.0.1:33978 - "GET /health HTTP/1.1" 200 OK
rag-svc         | [rag] synced tree:
rag-svc         | /app/rag_store:
rag-svc         | [rag] ERROR: required files not found:h
rag-svc         |   PERS_PATH=/app/rag_store/prompts/pers.json
rag-svc         |   SYSTEM_PROMPT_PATH=/app/rag_store/prompts/system_client.md
rag-svc         | [rag] ls -R /app/rag_store:
rag-svc         | /app/rag_store:
rag-svc exited with code 1 (restarting)
dependency failed to start: container rag-svc is unhealthy

## В итоге должно быть так, что:
- После `docker compose up --build` сервис `rag-svc` healthy.
- Внутри контейнера по пути `/app/rag_store/prompts/` лежат оба файла.